### PR TITLE
feat: accept 'max' reasoning effort for Codex models

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -329,7 +329,7 @@ Current built-in keys:
 | Key | Default | Description |
 |-----|---------|-------------|
 | `codex_model` | `gpt-5.5` | Shared default model for Codex-backed review and analysis |
-| `codex_effort` | `high` | Shared default reasoning effort (`xhigh`, `high`, `medium`, `low`) |
+| `codex_effort` | `high` | Shared default reasoning effort (`max`, `xhigh`, `high`, `medium`, `low`) |
 | `bitlesson_model` | `haiku` | Model used by the BitLesson selector agent |
 | `provider_mode` | unset | Optional runtime mode hint such as `codex-only` |
 | `agent_teams` | `false` | Project-level default for agent teams workflow |
@@ -343,7 +343,7 @@ All Codex-using features (RLCR loop, ask-codex) share the same model configurati
 | Key | Default | Description |
 |-----|---------|-------------|
 | `codex_model` | `gpt-5.5` | Model used for Codex operations (reviews, analysis, queries) |
-| `codex_effort` | `high` | Reasoning effort (`xhigh`, `high`, `medium`, `low`) |
+| `codex_effort` | `high` | Reasoning effort (`max`, `xhigh`, `high`, `medium`, `low`) |
 
 To override, add to `.humanize/config.json`:
 

--- a/hooks/lib/loop-common.sh
+++ b/hooks/lib/loop-common.sh
@@ -221,9 +221,9 @@ elif [[ -n "$_cfg_codex_model" && ! "$_cfg_codex_model" =~ ^(gpt-|o[0-9]) ]]; th
 fi
 DEFAULT_CODEX_MODEL="${DEFAULT_CODEX_MODEL:-${_cfg_codex_model:-gpt-5.5}}"
 _cfg_codex_effort="$(get_config_value "$_LOOP_COMMON_CONFIG" "codex_effort" 2>/dev/null || true)"
-if [[ -n "$_cfg_codex_effort" && ! "$_cfg_codex_effort" =~ ^(xhigh|high|medium|low)$ ]]; then
+if [[ -n "$_cfg_codex_effort" && ! "$_cfg_codex_effort" =~ ^(max|xhigh|high|medium|low)$ ]]; then
     echo "Warning: Invalid codex_effort in merged config: $_cfg_codex_effort" >&2
-    echo "  Must be one of: xhigh, high, medium, low" >&2
+    echo "  Must be one of: max, xhigh, high, medium, low" >&2
     echo "  Ignoring configured codex_effort; using caller preset or fallback" >&2
     _cfg_codex_effort=""
 fi

--- a/hooks/loop-codex-stop-hook.sh
+++ b/hooks/loop-codex-stop-hook.sh
@@ -176,9 +176,9 @@ if [[ ! "$CODEX_EXEC_MODEL" =~ ^[a-zA-Z0-9._-]+$ ]]; then
     end_loop "$LOOP_DIR" "$STATE_FILE" "$EXIT_UNEXPECTED"
     exit 0
 fi
-if [[ ! "$CODEX_EXEC_EFFORT" =~ ^(xhigh|high|medium|low)$ ]]; then
+if [[ ! "$CODEX_EXEC_EFFORT" =~ ^(max|xhigh|high|medium|low)$ ]]; then
     echo "Error: Invalid codex effort in state file: $CODEX_EXEC_EFFORT" >&2
-    echo "  Must be one of: xhigh, high, medium, low" >&2
+    echo "  Must be one of: max, xhigh, high, medium, low" >&2
     end_loop "$LOOP_DIR" "$STATE_FILE" "$EXIT_UNEXPECTED"
     exit 0
 fi

--- a/scripts/lib/model-router.sh
+++ b/scripts/lib/model-router.sh
@@ -73,16 +73,16 @@ map_effort() {
     esac
 
     case "$effort" in
-        xhigh|high|medium|low)
+        max|xhigh|high|medium|low)
             ;;
         *)
-            echo "Error: Unknown effort '$effort'. Expected one of: xhigh, high, medium, low." >&2
+            echo "Error: Unknown effort '$effort'. Expected one of: max, xhigh, high, medium, low." >&2
             return 1
             ;;
     esac
 
-    if [[ "$target_provider" == "claude" ]] && [[ "$effort" == "xhigh" ]]; then
-        echo "Info: Mapping effort 'xhigh' to 'high' for provider 'claude'." >&2
+    if [[ "$target_provider" == "claude" ]] && [[ "$effort" =~ ^(xhigh|max)$ ]]; then
+        echo "Info: Mapping effort '$effort' to 'high' for provider 'claude'." >&2
         echo "high"
         return 0
     fi

--- a/scripts/setup-rlcr-loop.sh
+++ b/scripts/setup-rlcr-loop.sh
@@ -719,9 +719,9 @@ if [[ ! "$CODEX_MODEL" =~ ^[a-zA-Z0-9._-]+$ ]]; then
 fi
 
 # Validate codex effort matches allowed values (consistent with stop-hook validation)
-if [[ ! "$CODEX_EFFORT" =~ ^(xhigh|high|medium|low)$ ]]; then
+if [[ ! "$CODEX_EFFORT" =~ ^(max|xhigh|high|medium|low)$ ]]; then
     echo "Error: Invalid codex effort: $CODEX_EFFORT" >&2
-    echo "  Must be one of: xhigh, high, medium, low" >&2
+    echo "  Must be one of: max, xhigh, high, medium, low" >&2
     exit 1
 fi
 

--- a/tests/test-model-router.sh
+++ b/tests/test-model-router.sh
@@ -420,6 +420,41 @@ else
 fi
 
 # ========================================
+# Test 21: max passes through for codex
+# ========================================
+echo ""
+echo "--- Test 21: max passes through for codex ---"
+echo ""
+
+result=""
+exit_code=0
+result=$(map_effort "max" "codex" 2>/dev/null) || exit_code=$?
+
+if [[ $exit_code -eq 0 ]] && [[ "$result" == "max" ]]; then
+    pass "map_effort: max passes through for codex"
+else
+    fail "map_effort: max passes through for codex" "exit 0 + max" "exit=$exit_code, output=$result"
+fi
+
+# ========================================
+# Test 22: max maps to high for claude
+# ========================================
+echo ""
+echo "--- Test 22: max maps to high for claude ---"
+echo ""
+
+exit_code=0
+stderr_out=""
+result=$(map_effort "max" "claude" 2> "$TEST_DIR/map-effort-max-stderr.txt") || exit_code=$?
+stderr_out="$(cat "$TEST_DIR/map-effort-max-stderr.txt")"
+
+if [[ $exit_code -eq 0 ]] && [[ "$result" == "high" ]] && echo "$stderr_out" | grep -qiE "mapping effort|max|high"; then
+    pass "map_effort: max maps to high for claude with info log"
+else
+    fail "map_effort: max maps to high for claude with info log" "exit 0 + high + info log" "exit=$exit_code, output=$result, stderr=$stderr_out"
+fi
+
+# ========================================
 # Summary
 # ========================================
 

--- a/tests/test-unified-codex-config.sh
+++ b/tests/test-unified-codex-config.sh
@@ -657,7 +657,7 @@ fi
 
 # Test invalid effort value
 invalid_effort="superhigh"
-if [[ ! "$invalid_effort" =~ ^(xhigh|high|medium|low)$ ]]; then
+if [[ ! "$invalid_effort" =~ ^(max|xhigh|high|medium|low)$ ]]; then
     pass "validation: invalid effort value is rejected by regex"
 else
     fail "validation: invalid effort value is rejected by regex"
@@ -665,7 +665,7 @@ fi
 
 # Test valid effort values
 for effort in xhigh high medium low; do
-    if [[ "$effort" =~ ^(xhigh|high|medium|low)$ ]]; then
+    if [[ "$effort" =~ ^(max|xhigh|high|medium|low)$ ]]; then
         pass "validation: effort '$effort' is accepted"
     else
         fail "validation: effort '$effort' is accepted"


### PR DESCRIPTION
## Motivation

Codex CLI >= 0.144.0 supports `model_reasoning_effort=max` (introduced alongside the GPT-5.6 model family, GA July 2026). Humanize currently rejects `max` at every validation site:

- `codex_effort: "max"` in `config.json` is silently ignored with a warning (`hooks/lib/loop-common.sh`)
- `start-rlcr-loop --codex-model MODEL:max` fails at setup (`scripts/setup-rlcr-loop.sh`)
- the stop hook rejects `max` when re-reading loop state (`hooks/loop-codex-stop-hook.sh`)
- `map_effort` errors on `max` (`scripts/lib/model-router.sh`)

So users on GPT-5.6 can't run RLCR reviews at the deepest reasoning tier even though their CLI supports it.

## Changes

- Add `max` to the four effort whitelists and the corresponding error messages
- `map_effort`: downgrade `max` -> `high` for the `claude` provider, same as the existing `xhigh` mapping (the info log now interpolates the actual effort value)
- `docs/usage.md`: update both `codex_effort` value lists
- `tests/test-unified-codex-config.sh`: keep the replicated validation regexes in sync
- `tests/test-model-router.sh`: add Test 21 (`max` passes through for codex) and Test 22 (`max` maps to `high` for claude)

## Testing

- `tests/test-model-router.sh`: new Tests 21/22 pass (Tests 11/13 fail only on my box because `codex`/`claude` exist in `/usr/bin`, which defeats the missing-binary simulation; unrelated to this change)
- `tests/test-unified-codex-config.sh`, `tests/test-config-merge.sh`, `tests/test-config-error-handling.sh`: all pass
- `bash -n` clean on all changed shell files
- Verified end-to-end on a patched install: `codex_effort: "max"` in config is accepted without warning and `ask-codex` runs with `model=gpt-5.6-sol effort=max`

🤖 Generated with [Claude Code](https://claude.com/claude-code)